### PR TITLE
Refine release header handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,46 +3,72 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build-ubuntu-latest:
+  release-build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         server_version: ['unstable', '8.0', '8.1']
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - name: Set the server version for python integration tests
-      run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
-    - name: Set up Python
-      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 #v3.1.4
-      with:
-        python-version: '3.9'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Build and Run tests. 
-      run: ./build.sh
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set the server version
+        run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
+      - name: Build release
+        run: ./build.sh --release
 
-  build-asan-ubuntu-latest:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         server_version: ['unstable', '8.0', '8.1']
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - name: Set the server version for python integration tests
-      run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
-    - name: Set up Python
-      uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 #v3.1.4
-      with:
-        python-version: '3.9'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Build and Run tests. 
-      run: |
-        export ASAN_BUILD=true
-        ./build.sh
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set the server version
+        run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
+      - name: Run unit tests
+        run: ./build.sh --unit
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        server_version: ['unstable', '8.0', '8.1']
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set the server version
+        run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
+      - name: Set up Python
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run integration tests
+        run: ./build.sh --integration
+
+  asan-integration:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        server_version: ['unstable', '8.0', '8.1']
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Set the server version
+        run: echo "SERVER_VERSION=${{ matrix.server_version }}" >> $GITHUB_ENV
+      - name: Set up Python
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run ASAN integration tests
+        run: |
+          export ASAN_BUILD=true
+          ./build.sh --integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run integration tests
         run: ./build.sh --integration
 
-  asan-integration:
+  asan-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -71,4 +71,4 @@ jobs:
       - name: Run ASAN integration tests
         run: |
           export ASAN_BUILD=true
-          ./build.sh --integration
+          ./build.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ set(JSON_MODULE_LIB json)
 # the `valkeymodule.h` header. When `RELEASE_BUILD` is enabled the build system
 # clones Valkey but does not compile it.
 option(RELEASE_BUILD "Clone Valkey only for valkeymodule.h" OFF)
+option(ENABLE_UNIT_TESTS "Enable unit tests" ON)
+option(ENABLE_INTEGRATION_TESTS "Enable integration tests" ON)
 
 # Define the Valkey directories used when building from source
 set(VALKEY_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/_deps/valkey-src")
@@ -61,26 +63,30 @@ if(ENABLE_ASAN)
 endif()
 
 message("CFLAGS: ${CFLAGS}")
-
+message("RELEASE_BUILD: ${RELEASE_BUILD}")
+message("ENABLE_UNIT_TESTS: ${ENABLE_UNIT_TESTS}")
+message("ENABLE_INTEGRATION_TESTS: ${ENABLE_INTEGRATION_TESTS}")
 # Determine Valkey build command depending on build type
-if(RELEASE_BUILD)
-    set(BUILD_CMD "")
+if((RELEASE_BUILD OR ENABLE_UNIT_TESTS) AND NOT ENABLE_INTEGRATION_TESTS)
+    set(VALKEY_BUILD_CMD ${CMAKE_COMMAND} -E echo "Skipping build step for release build")
 else()
     if(ENABLE_ASAN)
         message("Building Valkey engine with Address Sanitizer enabled")
-        set(BUILD_CMD make distclean && make -j SANITIZER=address)
+        set(VALKEY_BUILD_CMD make distclean && make -j SANITIZER=address)
     else()
-        set(BUILD_CMD make distclean && make -j)
+        set(VALKEY_BUILD_CMD make distclean && make -j)
     endif()
 endif()
 
+message("Valkey build command: ${VALKEY_BUILD_CMD}")
+message("CMAKE_CMD : ${CMAKE_COMMAND}")
 ExternalProject_Add(
     valkey
     GIT_REPOSITORY https://github.com/valkey-io/valkey.git
     GIT_TAG ${VALKEY_VERSION}
     PREFIX ${VALKEY_DOWNLOAD_DIR}
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${BUILD_CMD}
+    BUILD_COMMAND ${VALKEY_BUILD_CMD}
     INSTALL_COMMAND ""
     BUILD_IN_SOURCE 1
 )
@@ -100,18 +106,16 @@ ExternalProject_Add_Step(
     ALWAYS 1
 )
 
-if(NOT RELEASE_BUILD)
-    add_custom_command(TARGET valkey
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_BINARY_DEST}
-        COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_BIN_DIR}/valkey-server ${VALKEY_BINARY_DEST}/valkey-server
-        COMMENT "Copied valkey-server to destination directory"
-    )
-endif()
-
 # Integration tests require the valkey-test-framework which is only needed when
 # building Valkey from source.
-if(NOT RELEASE_BUILD)
+if(ENABLE_INTEGRATION_TESTS)
+    # Copy the valkey-server binary after building
+    add_custom_command(TARGET valkey
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_BINARY_DEST}
+            COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_BIN_DIR}/valkey-server ${VALKEY_BINARY_DEST}/valkey-server
+            COMMENT "Copied valkey-server to destination directory"
+        )
     # Define valkey-test-framework commit id
     set(VALKEY_TEST_FRAMEWORK_COMMIT "9fb28b74efd122324db00498a2fde6e5d281c90f" CACHE STRING "Valkey-test-framework commit to use")
 
@@ -194,9 +198,12 @@ FetchContent_MakeAvailable(rapidjson)
 
 add_subdirectory(src)
 
-add_subdirectory(tst)
+if(ENABLE_UNIT_TESTS OR ENABLE_INTEGRATION_TESTS)
+    add_subdirectory(tst)
+endif()
 
-if(NOT RELEASE_BUILD)
+if(ENABLE_INTEGRATION_TESTS)
+    message("adding test target")
     add_custom_target(test
         COMMENT "Run valkey-json integration tests"
         USES_TERMINAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,11 @@ endif()
 # Set the name of the JSON shared library
 set(JSON_MODULE_LIB json)
 
-# Skip building Valkey when building in release or unit-test mode. When
-# RELEASE_BUILD is ON the variable VALKEY_HEADER_DIR must point to the directory
-# containing `valkeymodule.h`. Only integration tests require the full Valkey
-# sources.
-option(RELEASE_BUILD "Skip building Valkey and use provided valkeymodule.h" OFF)
-set(VALKEY_HEADER_DIR "" CACHE PATH "Directory containing valkeymodule.h when RELEASE_BUILD=ON")
+# Skip building Valkey when building in release or unit-test mode. Integration
+# tests require the full Valkey sources while release and unit modes only need
+# the `valkeymodule.h` header. When `RELEASE_BUILD` is enabled the build system
+# clones Valkey but does not compile it.
+option(RELEASE_BUILD "Clone Valkey only for valkeymodule.h" OFF)
 
 # Define the Valkey directories used when building from source
 set(VALKEY_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/_deps/valkey-src")
@@ -63,55 +62,51 @@ endif()
 
 message("CFLAGS: ${CFLAGS}")
 
-# Build Valkey from source unless this is a release build
-if(NOT RELEASE_BUILD)
+# Determine Valkey build command depending on build type
+if(RELEASE_BUILD)
+    set(BUILD_CMD "")
+else()
     if(ENABLE_ASAN)
         message("Building Valkey engine with Address Sanitizer enabled")
         set(BUILD_CMD make distclean && make -j SANITIZER=address)
     else()
         set(BUILD_CMD make distclean && make -j)
     endif()
-
-    ExternalProject_Add(
-        valkey
-        GIT_REPOSITORY https://github.com/valkey-io/valkey.git
-        GIT_TAG ${VALKEY_VERSION}
-        PREFIX ${VALKEY_DOWNLOAD_DIR}
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND ${BUILD_CMD}
-        INSTALL_COMMAND ""
-        BUILD_IN_SOURCE 1
-    )
 endif()
+
+ExternalProject_Add(
+    valkey
+    GIT_REPOSITORY https://github.com/valkey-io/valkey.git
+    GIT_TAG ${VALKEY_VERSION}
+    PREFIX ${VALKEY_DOWNLOAD_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ${BUILD_CMD}
+    INSTALL_COMMAND ""
+    BUILD_IN_SOURCE 1
+)
 
 # Define the paths for the copied files
 set(VALKEY_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 set(VALKEY_BINARY_DEST "${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/.build/binaries/${VALKEY_VERSION}")
 
-if(NOT RELEASE_BUILD)
-    ExternalProject_Add_Step(
-        valkey
-        copy_header_files
-        COMMENT "Copying header files to include/ directory"
-        DEPENDEES download
-        DEPENDERS configure
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_INCLUDE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_DOWNLOAD_DIR}/src/valkey/src/valkeymodule.h ${VALKEY_INCLUDE_DIR}/valkeymodule.h
-        ALWAYS 1
-    )
+ExternalProject_Add_Step(
+    valkey
+    copy_header_files
+    COMMENT "Copying header files to include/ directory"
+    DEPENDEES download
+    DEPENDERS configure
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_INCLUDE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_DOWNLOAD_DIR}/src/valkey/src/valkeymodule.h ${VALKEY_INCLUDE_DIR}/valkeymodule.h
+    ALWAYS 1
+)
 
+if(NOT RELEASE_BUILD)
     add_custom_command(TARGET valkey
         POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_BINARY_DEST}
         COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_BIN_DIR}/valkey-server ${VALKEY_BINARY_DEST}/valkey-server
-        COMMENT "Copied valkeymodule.h and valkey-server to destination directories"
+        COMMENT "Copied valkey-server to destination directory"
     )
-else()
-    if(NOT VALKEY_HEADER_DIR)
-        message(FATAL_ERROR "VALKEY_HEADER_DIR must be set when RELEASE_BUILD is ON")
-    endif()
-    file(MAKE_DIRECTORY ${VALKEY_INCLUDE_DIR})
-    file(COPY "${VALKEY_HEADER_DIR}/valkeymodule.h" DESTINATION ${VALKEY_INCLUDE_DIR})
 endif()
 
 # Integration tests require the valkey-test-framework which is only needed when
@@ -127,7 +122,7 @@ if(NOT RELEASE_BUILD)
         valkey-test-framework
         GIT_REPOSITORY https://github.com/valkey-io/valkey-test-framework.git
         GIT_TAG ${VALKEY_TEST_FRAMEWORK_COMMIT}
-        GIT_SHALLOW TRUE
+        GIT_SHALLOW FALSE
         PREFIX "${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}"
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,14 @@ endif()
 # Set the name of the JSON shared library
 set(JSON_MODULE_LIB json)
 
-# Define the Valkey directories
+# Skip building Valkey when building in release or unit-test mode. When
+# RELEASE_BUILD is ON the variable VALKEY_HEADER_DIR must point to the directory
+# containing `valkeymodule.h`. Only integration tests require the full Valkey
+# sources.
+option(RELEASE_BUILD "Skip building Valkey and use provided valkeymodule.h" OFF)
+set(VALKEY_HEADER_DIR "" CACHE PATH "Directory containing valkeymodule.h when RELEASE_BUILD=ON")
+
+# Define the Valkey directories used when building from source
 set(VALKEY_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/_deps/valkey-src")
 set(VALKEY_BIN_DIR "${CMAKE_BINARY_DIR}/_deps/valkey-src/src/valkey/src")
 
@@ -56,75 +63,86 @@ endif()
 
 message("CFLAGS: ${CFLAGS}")
 
-if(ENABLE_ASAN)
-    message("Building Valkey engine with Address Sanitizer enabled")
-    set(BUILD_CMD make distclean && make -j SANITIZER=address)
-else()
-    set(BUILD_CMD make distclean && make -j)
-endif()
+# Build Valkey from source unless this is a release build
+if(NOT RELEASE_BUILD)
+    if(ENABLE_ASAN)
+        message("Building Valkey engine with Address Sanitizer enabled")
+        set(BUILD_CMD make distclean && make -j SANITIZER=address)
+    else()
+        set(BUILD_CMD make distclean && make -j)
+    endif()
 
-# Download and build Valkey with ASAN if enabled
-ExternalProject_Add(
-    valkey
-    GIT_REPOSITORY https://github.com/valkey-io/valkey.git
-    GIT_TAG ${VALKEY_VERSION}
-    PREFIX ${VALKEY_DOWNLOAD_DIR}
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${BUILD_CMD}
-    INSTALL_COMMAND ""
-    BUILD_IN_SOURCE 1
-)
+    ExternalProject_Add(
+        valkey
+        GIT_REPOSITORY https://github.com/valkey-io/valkey.git
+        GIT_TAG ${VALKEY_VERSION}
+        PREFIX ${VALKEY_DOWNLOAD_DIR}
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ${BUILD_CMD}
+        INSTALL_COMMAND ""
+        BUILD_IN_SOURCE 1
+    )
+endif()
 
 # Define the paths for the copied files
 set(VALKEY_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 set(VALKEY_BINARY_DEST "${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/.build/binaries/${VALKEY_VERSION}")
 
-ExternalProject_Add_Step(
-    valkey
-    copy_header_files
-    COMMENT "Copying header files to include/ directory"
-    DEPENDEES download
-    DEPENDERS configure
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_INCLUDE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_DOWNLOAD_DIR}/src/valkey/src/valkeymodule.h ${VALKEY_INCLUDE_DIR}/valkeymodule.h
-    ALWAYS 1
-)
+if(NOT RELEASE_BUILD)
+    ExternalProject_Add_Step(
+        valkey
+        copy_header_files
+        COMMENT "Copying header files to include/ directory"
+        DEPENDEES download
+        DEPENDERS configure
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_INCLUDE_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_DOWNLOAD_DIR}/src/valkey/src/valkeymodule.h ${VALKEY_INCLUDE_DIR}/valkeymodule.h
+        ALWAYS 1
+    )
 
-# Copy header and binary after Valkey make
-add_custom_command(TARGET valkey
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_BINARY_DEST}
-    COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_BIN_DIR}/valkey-server ${VALKEY_BINARY_DEST}/valkey-server
-    COMMENT "Copied valkeymodule.h and valkey-server to destination directories"
-)
+    add_custom_command(TARGET valkey
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${VALKEY_BINARY_DEST}
+        COMMAND ${CMAKE_COMMAND} -E copy ${VALKEY_BIN_DIR}/valkey-server ${VALKEY_BINARY_DEST}/valkey-server
+        COMMENT "Copied valkeymodule.h and valkey-server to destination directories"
+    )
+else()
+    if(NOT VALKEY_HEADER_DIR)
+        message(FATAL_ERROR "VALKEY_HEADER_DIR must be set when RELEASE_BUILD is ON")
+    endif()
+    file(MAKE_DIRECTORY ${VALKEY_INCLUDE_DIR})
+    file(COPY "${VALKEY_HEADER_DIR}/valkeymodule.h" DESTINATION ${VALKEY_INCLUDE_DIR})
+endif()
 
-# Define valkey-test-framework commit id
-set(VALKEY_TEST_FRAMEWORK_COMMIT "9fb28b74efd122324db00498a2fde6e5d281c90f" CACHE STRING "Valkey-test-framework commit to use")
+# Integration tests require the valkey-test-framework which is only needed when
+# building Valkey from source.
+if(NOT RELEASE_BUILD)
+    # Define valkey-test-framework commit id
+    set(VALKEY_TEST_FRAMEWORK_COMMIT "9fb28b74efd122324db00498a2fde6e5d281c90f" CACHE STRING "Valkey-test-framework commit to use")
 
-# Set the download directory for Valkey-test-framework
-set(VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-test-framework-src")
+    # Set the download directory for Valkey-test-framework
+    set(VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/valkey-test-framework-src")
 
-# Download valkey-test-framework
-ExternalProject_Add(
-    valkey-test-framework
-    GIT_REPOSITORY https://github.com/valkey-io/valkey-test-framework.git
-    GIT_TAG ${VALKEY_TEST_FRAMEWORK_COMMIT}
-    GIT_SHALLOW TRUE
-    PREFIX "${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}"
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-)
+    ExternalProject_Add(
+        valkey-test-framework
+        GIT_REPOSITORY https://github.com/valkey-io/valkey-test-framework.git
+        GIT_TAG ${VALKEY_TEST_FRAMEWORK_COMMIT}
+        GIT_SHALLOW TRUE
+        PREFIX "${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}"
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+    )
 
-# Step to copy pytest files
-ExternalProject_Add_Step(
-    valkey-test-framework
-    copy_pytest_files
-    COMMENT "Copying pytest files to tst/integration directory"
-    DEPENDEES build
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}/src/valkey-test-framework/src ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/valkeytests
-)
+    ExternalProject_Add_Step(
+        valkey-test-framework
+        copy_pytest_files
+        COMMENT "Copying pytest files to tst/integration directory"
+        DEPENDEES build
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${VALKEY_TEST_FRAMEWORK_DOWNLOAD_DIR}/src/valkey-test-framework/src ${CMAKE_CURRENT_SOURCE_DIR}/tst/integration/valkeytests
+    )
+endif()
 
 # Enable instrumentation options if requested
 if("$ENV{INSTRUMENT_V2PATH}" STREQUAL "yes")
@@ -183,12 +201,14 @@ add_subdirectory(src)
 
 add_subdirectory(tst)
 
-add_custom_target(test
-    COMMENT "Run valkey-json integration tests"
-    USES_TERMINAL
-    COMMAND rm -rf ${CMAKE_BINARY_DIR}/tst/integration
-    COMMAND mkdir -p ${CMAKE_BINARY_DIR}/tst/integration
-    COMMAND cp -rp ${CMAKE_SOURCE_DIR}/tst/integration/. ${CMAKE_BINARY_DIR}/tst/integration/
-    COMMAND echo "[TARGET] begin integration tests"
-    COMMAND ${CMAKE_SOURCE_DIR}/tst/integration/run.sh "test" ${CMAKE_SOURCE_DIR} 
-    COMMAND echo "[TARGET] end integration tests")
+if(NOT RELEASE_BUILD)
+    add_custom_target(test
+        COMMENT "Run valkey-json integration tests"
+        USES_TERMINAL
+        COMMAND rm -rf ${CMAKE_BINARY_DIR}/tst/integration
+        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/tst/integration
+        COMMAND cp -rp ${CMAKE_SOURCE_DIR}/tst/integration/. ${CMAKE_BINARY_DIR}/tst/integration/
+        COMMAND echo "[TARGET] begin integration tests"
+        COMMAND ${CMAKE_SOURCE_DIR}/tst/integration/run.sh "test" ${CMAKE_SOURCE_DIR}
+        COMMAND echo "[TARGET] end integration tests")
+endif()

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Custom compiler flags can be passed to the build script via environment variable
 ```text
 CFLAGS="-O0 -Wno-unused-function" ./build.sh
 ```
+# Additional build script options:
+```text
+# Build the module for release (clones Valkey for valkeymodule.h only)
+./build.sh --release
+# Run only unit tests
+./build.sh --unit
+# Run only integration tests
+./build.sh --integration
+```
+The script clones the Valkey repository to obtain `valkeymodule.h` for both `--release` and `--unit` unless you set `VALKEY_HEADER_DIR` to a custom directory.
 #### To build the module with ASAN and run tests
 ```text
 export ASAN_BUILD=true

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ CFLAGS="-O0 -Wno-unused-function" ./build.sh
 # Clean build and test artifacts
 ./build.sh --clean
 ```
-The script clones the Valkey repository to obtain `valkeymodule.h` for both `--release` and `--unit` unless you set `VALKEY_HEADER_DIR` to a custom directory.
+The script clones the Valkey repository automatically when `--release` or `--unit` is used so the build can copy `valkeymodule.h`.
 #### To build the module with ASAN and run tests
 ```text
 export ASAN_BUILD=true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ CFLAGS="-O0 -Wno-unused-function" ./build.sh
 ./build.sh --unit
 # Run only integration tests
 ./build.sh --integration
+# Clean build and test artifacts
+./build.sh --clean
 ```
 The script clones the Valkey repository to obtain `valkeymodule.h` for both `--release` and `--unit` unless you set `VALKEY_HEADER_DIR` to a custom directory.
 #### To build the module with ASAN and run tests
@@ -37,6 +39,8 @@ The script clones the Valkey repository to obtain `valkeymodule.h` for both `--r
 export ASAN_BUILD=true
 ./build.sh
 ```
+`ASAN_BUILD` works with any of the build script options and enables memory leak
+checks in the integration tests.
 
 #### To build just the module
 ```text
@@ -82,6 +86,8 @@ e.g.,
 TEST_PATTERN=test_sanity make -j test
 TEST_PATTERN=test_rdb.py make -j test
 ```
+You can also set `TEST_PATTERN` when running `build.sh` to pass the pattern through
+to the integration tests.
 
 ## Load the Module
 To test the module with a Valkey, you can load the module using any of the following ways:

--- a/README.md
+++ b/README.md
@@ -4,17 +4,25 @@ Valkey-json is a Valkey module written in C++ that provides native JSON (JavaScr
 
 Valkey-json leverages [RapidJSON](https://rapidjson.org/), a high-performance JSON parser and generator for C++, chosen for its small footprint and exceptional performance and memory efficiency. As a header-only library with no external dependencies, RapidJSON provides robust Unicode support while maintaining a compact memory profile of just 16 bytes per JSON value on most 32/64-bit machines.
 
-## Building and Testing
+### Building and testing the module
+Valkey JSON  uses CMake for its build system. To simplify, a build script is provided. 
 
-#### To build the module and run tests
+To build and run all tests, use:
 ```text
-# Build valkey-server (unstable) and run integration tests
 ./build.sh
 ```
-
-The default valkey version is "unstable". To override it, do:
+To build only valkey-json module, use:
 ```text
-# Build valkey-server (8.0) and run integration tests
+./build.sh --release
+```
+To view the available arguments, use:
+```text
+./build.sh --help
+```
+
+The default valkey version is "unstable" for integration tests. To override it, do:
+```text
+# Build valkey-server (8.0)
 SERVER_VERSION=8.0 ./build.sh
 ```
 
@@ -22,19 +30,8 @@ Custom compiler flags can be passed to the build script via environment variable
 ```text
 CFLAGS="-O0 -Wno-unused-function" ./build.sh
 ```
-# Additional build script options:
-```text
-# Build the module for release (clones Valkey for valkeymodule.h only)
-./build.sh --release
-# Run only unit tests
-./build.sh --unit
-# Run only integration tests
-./build.sh --integration
-# Clean build and test artifacts
-./build.sh --clean
-```
-The script clones the Valkey repository automatically when `--release` or `--unit` is used so the build can copy `valkeymodule.h`.
-#### To build the module with ASAN and run tests
+
+To build the module with ASAN and run tests
 ```text
 export ASAN_BUILD=true
 ./build.sh
@@ -42,52 +39,15 @@ export ASAN_BUILD=true
 `ASAN_BUILD` works with any of the build script options and enables memory leak
 checks in the integration tests.
 
-#### To build just the module
+To run single integration test:
 ```text
-mkdir build
-cd build
-cmake ..
-make
-```
-
-The default valkey version is "unstable". To override it, do:
-```text
-mkdir build
-cd build
-cmake .. -DVALKEY_VERSION=8.0
-make
-```
-
-Custom compiler flags can be passed to cmake via variable CFLAGS. For example:
-```text
-mkdir build
-cd build
-cmake .. -DCFLAGS="-O0 -Wno-unused-function"
-make
-```
-
-#### To run all unit tests:
-```text
-cd build
-make -j unit
-```
-
-#### To run all integration tests:
-```text
-make -j test
-```
-
-#### To run one integration test:
-```text
-TEST_PATTERN=<test-function-or-file> make -j test
+TEST_PATTERN=<test-function-or-file> ./build.sh --integration
 ```
 e.g.,
 ```text
-TEST_PATTERN=test_sanity make -j test
-TEST_PATTERN=test_rdb.py make -j test
+TEST_PATTERN=test_sanity ./build.sh --integration
+TEST_PATTERN=test_rdb.py ./build.sh --integration
 ```
-You can also set `TEST_PATTERN` when running `build.sh` to pass the pattern through
-to the integration tests.
 
 ## Load the Module
 To test the module with a Valkey, you can load the module using any of the following ways:

--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,25 @@
 
 set -e
 
-usage() {
-    echo "Usage: $0 [--release] [--unit] [--integration] [--clean]"
-    echo "  --release       Build only the module; clone Valkey for valkeymodule.h"
-    echo "  --unit          Run unit tests (clones Valkey for header)"
-    echo "  --integration   Run integration tests"
-    echo "  --clean         Remove build artifacts and exit"
-    exit 1
+function print_usage() {
+cat<<EOF
+Usage: build.sh [--release] [--unit] [--integration] [--clean]
+
+    --help | -h               Print this help message and exit.
+    --release                 Builds the release configuration.
+    --unit                    Builds the unit tests configuration.
+    --integration             Builds the integration tests configuration.
+    --clean                   Cleans the build artifacts.
+
+Example usage:
+
+    # Build the release configuration,
+    ./build.sh --release
+
+    # Cleans the build artifacts,
+    ./build.sh --clean
+
+EOF
 }
 
 SCRIPT_DIR=$(pwd)
@@ -18,8 +30,11 @@ RUN_INTEGRATION=1
 RELEASE_BUILD=0
 CLEAN_BUILD=0
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
+## Parse command line argument
+while [[ $# -gt 0 ]]; 
+do
+    arg="$1"
+    case $arg in
         --release)
             RELEASE_BUILD=1
             RUN_UNIT=0
@@ -28,7 +43,7 @@ while [[ $# -gt 0 ]]; do
         --unit)
             RUN_UNIT=1
             RUN_INTEGRATION=0
-            RELEASE_BUILD=1
+            RELEASE_BUILD=0
             ;;
         --integration)
             RUN_UNIT=0
@@ -39,16 +54,22 @@ while [[ $# -gt 0 ]]; do
             RUN_UNIT=0
             RUN_INTEGRATION=0
             ;;
-        *)
-            usage
+        --help|-h)
+            print_usage
+            exit 0
             ;;
-    esac
+        *)
+            print_usage
+            exit 1
+            ;;
+        esac
     shift
 done
 
 if [ $CLEAN_BUILD -eq 1 ]; then
     echo "Cleaning build artifacts..."
-    rm -rf "$BUILD_DIR" tst/integration/valkeytests tst/integration/.build src/include
+    rm -rf "$BUILD_DIR" tst/integration/valkeytests tst/integration/.build src/include 
+    rm -rf tst/integration/assets tst/integration/test-data tst/integration/report.html
     echo "Clean completed"
     exit 0
 fi
@@ -68,11 +89,25 @@ else
     CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release"
 fi
 
-if [ $RELEASE_BUILD -eq 1 ]; then
-    CMAKE_FLAGS="$CMAKE_FLAGS -DRELEASE_BUILD=ON"
+if [ $RUN_UNIT -eq 1 ]; then
+    ENABLE_UNIT_TESTS=ON
 else
-    CMAKE_FLAGS="$CMAKE_FLAGS -DRELEASE_BUILD=OFF"
+    ENABLE_UNIT_TESTS=OFF
 fi
+
+if [ $RUN_INTEGRATION -eq 1 ]; then
+    ENABLE_INTEGRATION_TESTS=ON
+else
+    ENABLE_INTEGRATION_TESTS=OFF
+fi
+
+if [ $RELEASE_BUILD -eq 1 ]; then
+    ENABLE_RELEASE_BUILD=ON
+else
+    ENABLE_RELEASE_BUILD=OFF
+fi
+
+CMAKE_FLAGS="$CMAKE_FLAGS -DENABLE_UNIT_TESTS=${ENABLE_UNIT_TESTS} -DENABLE_INTEGRATION_TESTS=${ENABLE_INTEGRATION_TESTS} -DRELEASE_BUILD=${ENABLE_RELEASE_BUILD}"
 
 if [ -z "${CFLAGS}" ]; then
     cmake .. -DVALKEY_VERSION=${SERVER_VERSION} ${CMAKE_FLAGS}
@@ -80,21 +115,18 @@ else
     cmake .. -DVALKEY_VERSION=${SERVER_VERSION} -DCFLAGS="${CFLAGS}" ${CMAKE_FLAGS}
 fi
 
-make -j
-
 if [ $RELEASE_BUILD -eq 1 ] && [ $RUN_UNIT -eq 0 ] && [ $RUN_INTEGRATION -eq 0 ]; then
+    make -j
     echo "Release build completed"
     exit 0
-fi
-
-if [ $RUN_UNIT -eq 1 ]; then
-    echo "Running unit tests..."
+elif [ $RUN_UNIT -eq 1 ]; then
     make -j unit
+    echo "Building valkey-json and running unit tests completed"
 fi
-
-cd "$SCRIPT_DIR"
 
 if [ $RUN_INTEGRATION -eq 1 ]; then
+    make -j
+    cd "$SCRIPT_DIR"
     REQUIREMENTS_FILE="requirements.txt"
     if command -v pip > /dev/null 2>&1; then
         pip install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
@@ -105,9 +137,9 @@ if [ $RUN_INTEGRATION -eq 1 ]; then
         exit 1
     fi
     export MODULE_PATH="$BUILD_DIR/src/libjson.so"
-    echo "Running integration tests..."
     cd "$BUILD_DIR"
-    make -j test
+    echo "Running integration tests...${TEST_PATTERN}"
+    TEST_PATTERN=${TEST_PATTERN} make -j test
 fi
 
 echo "Build script completed"

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,11 @@
 set -e
 
 usage() {
-    echo "Usage: $0 [--release] [--unit] [--integration]"
+    echo "Usage: $0 [--release] [--unit] [--integration] [--clean]"
     echo "  --release       Build only the module; clone Valkey for valkeymodule.h"
     echo "  --unit          Run unit tests (clones Valkey for header)"
     echo "  --integration   Run integration tests"
+    echo "  --clean         Remove build artifacts and exit"
     exit 1
 }
 
@@ -15,6 +16,7 @@ BUILD_DIR="$SCRIPT_DIR/build"
 RUN_UNIT=1
 RUN_INTEGRATION=1
 RELEASE_BUILD=0
+CLEAN_BUILD=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -32,12 +34,24 @@ while [[ $# -gt 0 ]]; do
             RUN_UNIT=0
             RUN_INTEGRATION=1
             ;;
+        --clean)
+            CLEAN_BUILD=1
+            RUN_UNIT=0
+            RUN_INTEGRATION=0
+            ;;
         *)
             usage
             ;;
     esac
     shift
 done
+
+if [ $CLEAN_BUILD -eq 1 ]; then
+    echo "Cleaning build artifacts..."
+    rm -rf "$BUILD_DIR" tst/integration/valkeytests tst/integration/.build src/include
+    echo "Clean completed"
+    exit 0
+fi
 
 if [ -z "$SERVER_VERSION" ]; then
     echo "SERVER_VERSION environment variable is not set. Defaulting to \"unstable\"."
@@ -63,7 +77,9 @@ if [ $RELEASE_BUILD -eq 1 ]; then
         fi
         VALKEY_HEADER_DIR="$VALKEY_CLONE_DIR/src"
     fi
-    CMAKE_FLAGS="$CMAKE_FLAGS -DRELEASE_BUILD=ON -DVALKEY_HEADER_DIR=$VALKEY_HEADER_DIR"
+    CMAKE_FLAGS="$CMAKE_FLAGS -DVALKEY_HEADER_DIR=$VALKEY_HEADER_DIR -DRELEASE_BUILD=ON"
+else
+    CMAKE_FLAGS="$CMAKE_FLAGS -DRELEASE_BUILD=OFF"
 fi
 
 if [ -z "${CFLAGS}" ]; then

--- a/build.sh
+++ b/build.sh
@@ -69,15 +69,7 @@ else
 fi
 
 if [ $RELEASE_BUILD -eq 1 ]; then
-    if [ -z "$VALKEY_HEADER_DIR" ]; then
-        VALKEY_CLONE_DIR="$BUILD_DIR/valkey-src"
-        if [ ! -d "$VALKEY_CLONE_DIR" ]; then
-            echo "Cloning Valkey repository for header..."
-            git clone --depth 1 --branch "$SERVER_VERSION" https://github.com/valkey-io/valkey.git "$VALKEY_CLONE_DIR"
-        fi
-        VALKEY_HEADER_DIR="$VALKEY_CLONE_DIR/src"
-    fi
-    CMAKE_FLAGS="$CMAKE_FLAGS -DVALKEY_HEADER_DIR=$VALKEY_HEADER_DIR -DRELEASE_BUILD=ON"
+    CMAKE_FLAGS="$CMAKE_FLAGS -DRELEASE_BUILD=ON"
 else
     CMAKE_FLAGS="$CMAKE_FLAGS -DRELEASE_BUILD=OFF"
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,68 +1,105 @@
 #!/bin/bash
 
-# Script to build valkey-json module, build it and generate .so files, run unit and integration tests.
-
-# # Exit the script if any command fails
 set -e
 
-SCRIPT_DIR=$(pwd)
-echo "Script Directory: $SCRIPT_DIR"
+usage() {
+    echo "Usage: $0 [--release] [--unit] [--integration]"
+    echo "  --release       Build only the module; clone Valkey for valkeymodule.h"
+    echo "  --unit          Run unit tests (clones Valkey for header)"
+    echo "  --integration   Run integration tests"
+    exit 1
+}
 
-# If environment variable SERVER_VERSION is not set, default to "unstable"
+SCRIPT_DIR=$(pwd)
+BUILD_DIR="$SCRIPT_DIR/build"
+RUN_UNIT=1
+RUN_INTEGRATION=1
+RELEASE_BUILD=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --release)
+            RELEASE_BUILD=1
+            RUN_UNIT=0
+            RUN_INTEGRATION=0
+            ;;
+        --unit)
+            RUN_UNIT=1
+            RUN_INTEGRATION=0
+            RELEASE_BUILD=1
+            ;;
+        --integration)
+            RUN_UNIT=0
+            RUN_INTEGRATION=1
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
 if [ -z "$SERVER_VERSION" ]; then
     echo "SERVER_VERSION environment variable is not set. Defaulting to \"unstable\"."
     export SERVER_VERSION="unstable"
 fi
 
-# Variables
-BUILD_DIR="$SCRIPT_DIR/build"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
 
-# Build the Valkey JSON module using CMake
-echo "Building valkey-json..."
-if [ ! -d "$BUILD_DIR" ]; then
-    mkdir $BUILD_DIR
-fi
-cd $BUILD_DIR
-
-if [ ! -z "${ASAN_BUILD}" ]; then
+CMAKE_FLAGS=""
+if [ -n "${ASAN_BUILD}" ]; then
     CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON"
 else
-    CMAKE_FLAGS=""
+    CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release"
+fi
+
+if [ $RELEASE_BUILD -eq 1 ]; then
+    if [ -z "$VALKEY_HEADER_DIR" ]; then
+        VALKEY_CLONE_DIR="$BUILD_DIR/valkey-src"
+        if [ ! -d "$VALKEY_CLONE_DIR" ]; then
+            echo "Cloning Valkey repository for header..."
+            git clone --depth 1 --branch "$SERVER_VERSION" https://github.com/valkey-io/valkey.git "$VALKEY_CLONE_DIR"
+        fi
+        VALKEY_HEADER_DIR="$VALKEY_CLONE_DIR/src"
+    fi
+    CMAKE_FLAGS="$CMAKE_FLAGS -DRELEASE_BUILD=ON -DVALKEY_HEADER_DIR=$VALKEY_HEADER_DIR"
 fi
 
 if [ -z "${CFLAGS}" ]; then
-  cmake .. -DVALKEY_VERSION=${SERVER_VERSION} ${CMAKE_FLAGS}
+    cmake .. -DVALKEY_VERSION=${SERVER_VERSION} ${CMAKE_FLAGS}
 else
-  cmake .. -DVALKEY_VERSION=${SERVER_VERSION} -DCFLAGS=${CFLAGS} ${CMAKE_FLAGS}
-fi
-make
-
-# Running the Valkey JSON unit tests.
-echo "Running Unit Tests..."
-make -j unit
-
-cd $SCRIPT_DIR
-
-REQUIREMENTS_FILE="requirements.txt"
-
-# Check if pip is available
-if command -v pip > /dev/null 2>&1; then
-    echo "Using pip to install packages..."
-    pip install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
-# Check if pip3 is available
-elif command -v pip3 > /dev/null 2>&1; then
-    echo "Using pip3 to install packages..."
-    pip3 install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
-else
-    echo "Error: Neither pip nor pip3 is available. Please install Python package installer."
-    exit 1
+    cmake .. -DVALKEY_VERSION=${SERVER_VERSION} -DCFLAGS="${CFLAGS}" ${CMAKE_FLAGS}
 fi
 
-export MODULE_PATH="$SCRIPT_DIR/build/src/libjson.so"
+make -j
 
-# Running the Valkey JSON integration tests.
-echo "Running the integration tests..."
-cd $BUILD_DIR
-make -j test
+if [ $RELEASE_BUILD -eq 1 ] && [ $RUN_UNIT -eq 0 ] && [ $RUN_INTEGRATION -eq 0 ]; then
+    echo "Release build completed"
+    exit 0
+fi
 
-echo "Build and Integration Tests succeeded"
+if [ $RUN_UNIT -eq 1 ]; then
+    echo "Running unit tests..."
+    make -j unit
+fi
+
+cd "$SCRIPT_DIR"
+
+if [ $RUN_INTEGRATION -eq 1 ]; then
+    REQUIREMENTS_FILE="requirements.txt"
+    if command -v pip > /dev/null 2>&1; then
+        pip install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
+    elif command -v pip3 > /dev/null 2>&1; then
+        pip3 install -r "$SCRIPT_DIR/$REQUIREMENTS_FILE"
+    else
+        echo "Error: Neither pip nor pip3 is available."
+        exit 1
+    fi
+    export MODULE_PATH="$BUILD_DIR/src/libjson.so"
+    echo "Running integration tests..."
+    cd "$BUILD_DIR"
+    make -j test
+fi
+
+echo "Build script completed"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,4 @@ target_sources(${OBJECT_TARGET}
 )
 
 add_library(${JSON_MODULE_LIB} SHARED $<TARGET_OBJECTS:${OBJECT_TARGET}>)
-
-if(NOT RELEASE_BUILD)
-    add_dependencies(${OBJECT_TARGET} valkey)
-endif()
+add_dependencies(${OBJECT_TARGET} valkey)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,8 +19,9 @@ target_include_directories(${OBJECT_TARGET}
 	# Need to make the source files public within CMake
 	# so that they are used when building the tests.
 	PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${rapidjson_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${rapidjson_SOURCE_DIR}/include
 )
 
 # Add source files for the JSON module
@@ -38,3 +39,7 @@ target_sources(${OBJECT_TARGET}
 )
 
 add_library(${JSON_MODULE_LIB} SHARED $<TARGET_OBJECTS:${OBJECT_TARGET}>)
+
+if(NOT RELEASE_BUILD)
+    add_dependencies(${OBJECT_TARGET} valkey)
+endif()

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -3,17 +3,19 @@
 ##################################################
 message("tst/CMakeLists.txt")
 
-# Fetch GoogleTest.
-include(FetchContent)
+if(ENABLE_UNIT_TESTS)
+  # Fetch GoogleTest.
+  include(FetchContent)
 
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # release-1.12.1
-  OVERRIDE_FIND_PACKAGE)
-FetchContent_MakeAvailable(googletest)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # release-1.12.1
+    OVERRIDE_FIND_PACKAGE)
+  FetchContent_MakeAvailable(googletest)
 
 
-include(GoogleTest)
+  include(GoogleTest)
 
-add_subdirectory(unit)
+  add_subdirectory(unit)
+endif()


### PR DESCRIPTION
## Summary
- rename build switch to `RELEASE_BUILD`
- clone Valkey automatically when skipping Valkey build
- document new build flags in README
- tweak build script logic and usage text

## Testing
- `./build.sh --release`
- `./build.sh --unit` *(produces long log)*
- `./build.sh --integration` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684b012295b88321bae72ad1941e3500