### PR TITLE
fix: gate JSON.DEBUG KEYTABLE-CORRUPT behind json.debug-mode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,44 @@ valkey-server --loadmodule /path/to/libjson.so
 2. Execute Valkey command:
     MODULE LOAD /path/to/libjson.so
 ```
+
+## Configuration
+
+### Document path limit (`json.max-path-limit`)
+
+JSON documents are subject to a **maximum nesting depth** (path limit). This limit caps how deeply objects and arrays can be nested (e.g. `a.b.c.d...`). It is used to avoid unbounded recursion and stack overflow when parsing, merging, or traversing documents.
+
+- **Config key:** `json.max-path-limit`
+- **Default:** 128
+- **Range:** 0 to INT_MAX
+
+If an operation would create or load a document whose nesting depth exceeds this limit, the module returns an error: *"Document path nesting limit is exceeded"*. The same limit is enforced when merging values (e.g. with `JSON.MERGE` or merge semantics in `JSON.SET`): once the recursion depth reaches the limit, merging stops and the new value is used as-is for the remainder of the path.
+
+To change the limit (e.g. to 256):
+
+```text
+CONFIG SET json.max-path-limit 256
+```
+
+### Debug commands (`json.debug-mode`)
+
+The `JSON.DEBUG KEYTABLE-CORRUPT`, `JSON.DEBUG KEYTABLE-CLEAR`, and `JSON.DEBUG KEYTABLE-DISTRIBUTION` subcommands are intended for development and debugging only. They are gated behind the `json.debug-mode` hidden module config, which is **immutable** — it can only be set at module load time.
+
+To enable debug commands, load the module and set the config via Valkey's CLI or config file:
+
+```text
+valkey-server --loadmodule /path/to/libjson.so --json.debug-mode yes
+```
+
+Or in `valkey.conf`:
+
+```text
+loadmodule /path/to/libjson.so
+json.debug-mode yes
+```
+
+When `debug-mode` is not enabled (the default), these subcommands return an error.
+
 ## Supported  Module Commands
 ```text
 JSON.ARRAPPEND

--- a/src/commands/json.debug.json
+++ b/src/commands/json.debug.json
@@ -1,6 +1,6 @@
 {
     "JSON.DEBUG": {
-        "summary": "Reports information. Supported subcommands are: MEMORY, DEPTH, FIELDS, HELP",
+        "summary": "Reports information. Supported subcommands are: MEMORY, DEPTH, FIELDS, HELP. KEYTABLE-CORRUPT, KEYTABLE-CLEAR, and KEYTABLE-DISTRIBUTION subcommands require 'json.debug-mode' to be enabled at module load time.",
         "complexity": "O(1)",
         "group": "json",
         "module_since": "1.0.0",

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -35,6 +35,8 @@
 
 #include <string>
 #include <cmath>
+#include <mutex>
+#include <vector>
 
 /* In unstable branch the module version is always "999999". */
 #define MODULE_VERSION 999999
@@ -74,11 +76,16 @@ static size_t config_max_recursive_descent_tokens = DEFAULT_MAX_RECURSIVE_DESCEN
 #define DEFAULT_MAX_QUERY_STRING_SIZE (128 * 1024)  // 128KB
 static size_t config_max_query_string_size = DEFAULT_MAX_QUERY_STRING_SIZE;
 
+static int config_debug_mode = 0;
+
 #define DEFAULT_KEY_TABLE_SHARDS 32768
 #define DEFAULT_HASH_TABLE_MIN_SIZE 64
 KeyTable *keyTable = nullptr;
 rapidjson::HashTableFactors rapidjson::hashTableFactors;
 rapidjson::HashTableStats   rapidjson::hashTableStats;
+
+static std::mutex debug_corrupt_mutex;
+static std::vector<KeyTable_Handle> debug_corrupt_handles;
 
 extern size_t hash_function(const char *text, size_t length);
 
@@ -2080,6 +2087,10 @@ STATIC int TestSharedApi(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int ar
     return VALKEYMODULE_OK;
 }
 
+static bool isDebugModeEnabled() {
+    return config_debug_mode != 0;
+}
+
 int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
     ValkeyModule_AutoMemory(ctx);
 
@@ -2210,6 +2221,10 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
             return VALKEYMODULE_ERR;
         }
 
+        if (!isDebugModeEnabled()) {
+            return ValkeyModule_ReplyWithError(ctx, "ERR unknown subcommand 'KEYTABLE-CORRUPT'. Try JSON.DEBUG HELP.");
+        }
+
         // ATTENTION:
         // THIS IS AN UNDOCUMENTED SUBCOMMAND, TO BE USED FOR DEV TEST ONLY. DON'T RUN IT ON A PRODUCTION SYSTEM.
         //
@@ -2223,13 +2238,45 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         const char *str = ValkeyModule_StringPtrLen(argv[2], &len);
 
         KeyTable_Handle h = keyTable->makeHandle(str, len);
-        ValkeyModule_Log(ctx, "warning", "*** Handle %s count is now %zd", str, h->getRefCount());
+        ValkeyModule_Log(ctx, "warning",
+                         "KEYTABLE-CORRUPT: injected handle for input of %zu bytes, refcount=%zd",
+                         len, h->getRefCount());
+        {
+            std::lock_guard<std::mutex> lk(debug_corrupt_mutex);
+            debug_corrupt_handles.push_back(std::move(h));
+        }
         return ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    } else if (!strcasecmp(subcmd, "KEYTABLE-CLEAR")) {
+        if (ValkeyModule_IsKeysPositionRequest(ctx)) {
+            return VALKEYMODULE_ERR;
+        }
+
+        if (!isDebugModeEnabled()) {
+            return ValkeyModule_ReplyWithError(ctx, "ERR unknown subcommand 'KEYTABLE-CLEAR'. Try JSON.DEBUG HELP.");
+        }
+
+        if (argc != 2) return ValkeyModule_WrongArity(ctx);
+
+        size_t count;
+        {
+            std::lock_guard<std::mutex> lk(debug_corrupt_mutex);
+            count = debug_corrupt_handles.size();
+            for (auto &h : debug_corrupt_handles) {
+                keyTable->destroyHandle(h);
+            }
+            debug_corrupt_handles.clear();
+        }
+        ValkeyModule_Log(ctx, "warning", "KEYTABLE-CLEAR: released %zu injected handles", count);
+        return ValkeyModule_ReplyWithLongLong(ctx, count);
     } else if (!strcasecmp(subcmd, "KEYTABLE-DISTRIBUTION")) {
         // compute longest runs of non-empty hashtable entries, a direct measure of key distribution and
         // worst-case run-time for lookup/insert/delete
         if (ValkeyModule_IsKeysPositionRequest(ctx)) {
             return VALKEYMODULE_ERR;
+        }
+
+        if (!isDebugModeEnabled()) {
+            return ValkeyModule_ReplyWithError(ctx, "ERR unknown subcommand 'KEYTABLE-DISTRIBUTION'. Try JSON.DEBUG HELP.");
         }
 
         // ATTENTION:
@@ -2282,6 +2329,7 @@ int Command_JsonDebug(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc)
         cmds.push_back("JSON.DEBUG MAX-SIZE-KEY  - Find JSON key with largest memory size");
         cmds.push_back("JSON.DEBUG KEYTABLE-CHECK - Extended KeyTable integrity check");
         cmds.push_back("JSON.DEBUG KEYTABLE-CORRUPT <name> - Intentionally corrupt KeyTable handle counts");
+        cmds.push_back("JSON.DEBUG KEYTABLE-CLEAR - Release all handles injected by KEYTABLE-CORRUPT");
         cmds.push_back("JSON.DEBUG KEYTABLE-DISTRIBUTION <topN> - Find and count topN longest runs in KeyTable");
         cmds.push_back("JSON.DEBUG TEST-SHARED-API <key> <path> - Provide testing for Shared api interface for search");
 
@@ -2552,12 +2600,31 @@ int Config_SetSizeConfig(const char *name, long long val, void *privdata, Valkey
     return VALKEYMODULE_OK;
 }
 
+int Config_GetBoolConfig(const char *name, void *privdata) {
+    VALKEYMODULE_NOT_USED(name);
+    return *static_cast<int*>(privdata);
+}
+
+int Config_SetBoolConfig(const char *name, int val, void *privdata, ValkeyModuleString **err) {
+    VALKEYMODULE_NOT_USED(name);
+    VALKEYMODULE_NOT_USED(err);
+    *static_cast<int*>(privdata) = val;
+    return VALKEYMODULE_OK;
+}
+
 int registerModuleConfigs(ValkeyModuleCtx *ctx) {
     REGISTER_NUMERIC_CONFIG(ctx, "max-document-size", DEFAULT_MAX_DOCUMENT_SIZE, VALKEYMODULE_CONFIG_MEMORY,
                             0, LLONG_MAX, &config_max_document_size, Config_GetSizeConfig, Config_SetSizeConfig)
 
     REGISTER_NUMERIC_CONFIG(ctx, "max-path-limit", DEFAULT_MAX_PATH_LIMIT, VALKEYMODULE_CONFIG_DEFAULT,
                             0, INT_MAX, &config_max_path_limit, Config_GetSizeConfig, Config_SetSizeConfig)
+
+    if (ValkeyModule_RegisterBoolConfig(ctx, "debug-mode", 0,
+            VALKEYMODULE_CONFIG_HIDDEN | VALKEYMODULE_CONFIG_IMMUTABLE,
+            Config_GetBoolConfig, Config_SetBoolConfig, nullptr, &config_debug_mode) == VALKEYMODULE_ERR) {
+        ValkeyModule_Log(ctx, "warning", "Failed to register module config \"debug-mode\".");
+        return VALKEYMODULE_ERR;
+    }
 
     ValkeyModule_LoadConfigs(ctx);
     return VALKEYMODULE_OK;
@@ -2954,11 +3021,15 @@ extern "C" int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx) {
         ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-CHECK for command JSON.DEBUG.");
         return VALKEYMODULE_ERR;
     }
-    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-CORRUPT", Command_JsonDebug, "", 2, 2, 1) == VALKEYMODULE_ERR) {
+    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-CORRUPT", Command_JsonDebug, "admin", 2, 2, 1) == VALKEYMODULE_ERR) {
         ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-CORRUPT for command JSON.DEBUG.");
         return VALKEYMODULE_ERR;
     }
-    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-DISTRIBUTION", Command_JsonDebug, "", 0, 0, 0)
+    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-CLEAR", Command_JsonDebug, "admin", 0, 0, 0) == VALKEYMODULE_ERR) {
+        ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-CLEAR for command JSON.DEBUG.");
+        return VALKEYMODULE_ERR;
+    }
+    if (ValkeyModule_CreateSubcommand(parent, "KEYTABLE-DISTRIBUTION", Command_JsonDebug, "admin", 0, 0, 0)
         == VALKEYMODULE_ERR) {
         ValkeyModule_Log(ctx, "warning", "Failed to create subcommand KEYTABLE-DISTRIBUTION for command JSON.DEBUG.");
         return VALKEYMODULE_ERR;
@@ -3072,6 +3143,7 @@ extern "C" int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx) {
     if (!set_command_info(ctx, "JSON.DEBUG|MAX-SIZE-KEY", 2)) return VALKEYMODULE_ERR;
     if (!set_command_info(ctx, "JSON.DEBUG|KEYTABLE-CHECK", 2)) return VALKEYMODULE_ERR;
     if (!set_command_info(ctx, "JSON.DEBUG|KEYTABLE-CORRUPT", 3)) return VALKEYMODULE_ERR;
+    if (!set_command_info(ctx, "JSON.DEBUG|KEYTABLE-CLEAR", 2)) return VALKEYMODULE_ERR;
     if (!set_command_info(ctx, "JSON.DEBUG|KEYTABLE-DISTRIBUTION", 3)) return VALKEYMODULE_ERR;
 
     if (!memory_traps_control(false)) {

--- a/tst/integration/json_test_case.py
+++ b/tst/integration/json_test_case.py
@@ -76,7 +76,7 @@ class JsonTestCase(SimpleTestCase):
         else:
             # Original local server
             server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            args = {'loadmodule': os.getenv('MODULE_PATH'), 'json.debug-mode': 'yes', "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
             self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester

--- a/tst/integration/test_json_basic.py
+++ b/tst/integration/test_json_basic.py
@@ -182,7 +182,7 @@ class TestJsonBasic(JsonTestCase):
         else:
             # Original local server setup
             server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
-            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            args = {'loadmodule': os.getenv('MODULE_PATH'), 'json.debug-mode': 'yes', "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
             self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
 
         self.error_class = ErrorStringTester
@@ -2747,6 +2747,33 @@ class TestJsonBasic(JsonTestCase):
         exp_val = client.execute_command('JSON.DEBUG','MEMORY',wikipedia,'.')
         assert exp_val == metadate_val
 
+    def test_keytable_corrupt_injects_handle(self):
+        """JSON.DEBUG KEYTABLE-CORRUPT should inject a handle that KEYTABLE-CHECK detects as a mismatch."""
+        client = self.server.get_new_client()
+        # Baseline: KEYTABLE-CHECK should succeed
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CHECK')
+        # Inject a handle
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'unique_test_corrupt_string_abc123')
+        # KEYTABLE-CHECK now detects the mismatch
+        with pytest.raises(ResponseError, match="Mismatch"):
+            client.execute_command('JSON.DEBUG', 'KEYTABLE-CHECK')
+        # Clean up so teardown doesn't trip the assertion
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CLEAR')
+
+    def test_keytable_clear_releases_handles(self):
+        """JSON.DEBUG KEYTABLE-CLEAR should release all injected handles and restore integrity."""
+        client = self.server.get_new_client()
+        # Inject 3 handles
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'clear_test_string_1')
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'clear_test_string_2')
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'clear_test_string_3')
+        # Clear them
+        cleared = client.execute_command('JSON.DEBUG', 'KEYTABLE-CLEAR')
+        assert cleared == 3, f"Expected 3 cleared handles, got {cleared}"
+        # KEYTABLE-CHECK succeeds again after cleanup
+        client.execute_command('JSON.DEBUG', 'KEYTABLE-CHECK')
+
+
     def test_json_duplicate_keys(self):
         client = self.server.get_new_client()
         '''Test handling of object with duplicate keys'''
@@ -4213,7 +4240,7 @@ class TestJsonBasic(JsonTestCase):
         cmd_arity = [('MEMORY', -3), ('FIELDS', -3), ('DEPTH', 3), ('HELP', 2),
                      ('MAX-DEPTH-KEY', 2), ('MAX-SIZE-KEY',
                                             2), ('KEYTABLE-CHECK', 2), ('KEYTABLE-CORRUPT', 3),
-                     ('KEYTABLE-DISTRIBUTION', 3), ('TEST-SHARED-API', -2)]
+                     ('KEYTABLE-CLEAR', 2), ('KEYTABLE-DISTRIBUTION', 3), ('TEST-SHARED-API', -2)]
         subcmd_dict = {f'JSON.DEBUG|{cmd}': arity for cmd, arity in cmd_arity}
 
         output = client.execute_command(
@@ -4355,3 +4382,43 @@ class TestJsonBasic(JsonTestCase):
             s = client.execute_command("json.debug", "test-shared-api", "k1", path)
             print("For Path:", path, " json.get:", g, " shared-api:", s)
             assert (g == s)
+
+
+class TestJsonDebugGating(JsonTestCase):
+    """Test that debug commands are gated behind json.debug-mode module config."""
+
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        use_external = os.environ.get("VALKEY_EXTERNAL_SERVER", "false").lower() == "true"
+
+        if use_external:
+            external_host = os.environ.get("VALKEY_HOST", "localhost")
+            external_port = int(os.environ.get("VALKEY_PORT", "6379"))
+            self.server, self.client = self.create_server(
+                testdir=self.testdir,
+                bind_ip=external_host,
+                port=external_port,
+                external_server=True
+            )
+        else:
+            server_path = f"{os.path.dirname(os.path.realpath(__file__))}/.build/binaries/{os.environ['SERVER_VERSION']}/valkey-server"
+            # Load module WITHOUT debug-mode — commands should be gated
+            args = {'loadmodule': os.getenv('MODULE_PATH'), "enable-debug-command": "local", 'enable-protected-configs': 'yes'}
+            self.server, self.client = self.create_server(testdir=self.testdir, server_path=server_path, args=args)
+
+        self.error_class = ErrorStringTester
+
+    def test_keytable_corrupt_requires_debug_mode(self):
+        """KEYTABLE-CORRUPT should be rejected without debug-mode."""
+        with pytest.raises(ResponseError, match="unknown subcommand"):
+            self.client.execute_command('JSON.DEBUG', 'KEYTABLE-CORRUPT', 'test_string')
+
+    def test_keytable_clear_requires_debug_mode(self):
+        """KEYTABLE-CLEAR should be rejected without debug-mode."""
+        with pytest.raises(ResponseError, match="unknown subcommand"):
+            self.client.execute_command('JSON.DEBUG', 'KEYTABLE-CLEAR')
+
+    def test_keytable_distribution_requires_debug_mode(self):
+        """KEYTABLE-DISTRIBUTION should be rejected without debug-mode."""
+        with pytest.raises(ResponseError, match="unknown subcommand"):
+            self.client.execute_command('JSON.DEBUG', 'KEYTABLE-DISTRIBUTION', '10')


### PR DESCRIPTION
## Issue

`JSON.DEBUG KEYTABLE-CORRUPT <string>` was an unrecoverable memory-exhaustion DoS:

- Each call allocated a `KeyTable_Layout` containing the full user-supplied string via `makeHandle()`
- The returned handle was never released — nothing held a reference to decrement
- **Any user with `+@json` ACL permission** could trigger it
- **FLUSHALL did not reclaim the memory** (KeyTable is global, not per-key)
- **Only a server restart recovered** the leaked memory

### Demonstrated impact

- 100 calls with 1MB strings → 131MB leaked in seconds
- 10 calls with 10MB strings → another 120MB in 0.5 seconds
- Attack rate: ~200MB/s with 10MB strings
- A 16GB server could be OOM-killed in under 2 minutes

### Why it existed

The command was a development-time **fault-injection tool** paired with `KEYTABLE-CHECK` (the KeyTable integrity validator). It shipped in the initial module contribution without being wired into any automated test, and was assumed safe because operators "wouldn't expose debug commands in production" — but it was reachable via the normal `@json` ACL.

## Fix

This PR applies a **three-layer defense** and restores the command's original debugging purpose:

### 1. Hidden, immutable module config `json.debug-mode`

- Default: `false`
- `HIDDEN` — not shown in `CONFIG GET`
- `IMMUTABLE` — can only be set at module load time, not via runtime `CONFIG SET`
- Set via module load args:
  ```
  loadmodule /path/to/libjson.so debug-mode yes
  ```
  Or in `valkey.conf`:
  ```
  loadmodule /path/to/libjson.so debug-mode yes
  ```

### 2. `admin` command flag on gated subcommands

`KEYTABLE-CORRUPT`, `KEYTABLE-CLEAR`, and `KEYTABLE-DISTRIBUTION` now require the `@admin` ACL category. Users with `+@json -@admin` cannot reach them even if `debug-mode=yes`.

### 3. Restored fault-injection + recovery path

- `KEYTABLE-CORRUPT` keeps its original semantics — the injected handle is stored in a mutex-protected module-global registry (`std::vector<KeyTable_Handle>`) so `KEYTABLE-CHECK` can still detect the corruption during development.
- **New subcommand `JSON.DEBUG KEYTABLE-CLEAR`** drains the registry: calls `destroyHandle()` on every stored handle and returns the count. This makes the "leak" recoverable without restarting the server.
- Log line changed to length + refcount only — no attacker-controlled string in logs.

## Behavior summary

| Command | With `debug-mode=no` (default) | With `debug-mode=yes` |
|---------|--------------------------------|------------------------|
| `KEYTABLE-CORRUPT` | `ERR unknown subcommand` | Injects handle into registry (requires `@admin`) |
| `KEYTABLE-CLEAR` | `ERR unknown subcommand` | Drains registry, returns count (requires `@admin`) |
| `KEYTABLE-DISTRIBUTION` | `ERR unknown subcommand` | Returns stats (requires `@admin`) |
| `MEMORY`, `FIELDS`, `DEPTH`, `HELP`, `KEYTABLE-CHECK`, `MAX-*-KEY`, `TEST-SHARED-API` | Unchanged | Unchanged |

## Design choice: why a module config, not Valkey's `enable-debug-command`

Followed the [valkey-search](https://github.com/valkey-io/valkey-search) pattern (`search.debug-mode`):
- No cross-module dependency on a server-level config
- Module owns its own lifecycle
- Hidden config keeps the surface minimal
- Immutable prevents runtime enable via config poisoning

## Tests

- `test_keytable_corrupt_injects_handle` — verifies `CORRUPT` increases handle count reported by `KEYTABLE-CHECK`
- `test_keytable_clear_releases_handles` — 3 injections, `CLEAR` returns 3, handle count returns to baseline
- `TestJsonDebugGating` class — loads module **without** `debug-mode yes`, verifies all three gated commands return `ERR unknown subcommand`
- `cmd_arity` / `COMMAND INFO` test updated for the new `KEYTABLE-CLEAR` subcommand

## Files changed

| File | Change |
|------|--------|
| `src/json/json.cc` | Config, handle registry, restored CORRUPT, new CLEAR, gating, admin flag |
| `tst/integration/json_test_case.py` | Load module with `debug-mode yes` for tests that exercise debug commands |
| `tst/integration/test_json_basic.py` | Regression tests, gating tests, arity update |
| `CHANGELOG.md` | New file — security + feature entries |
| `README.md` | Added "Debug commands (`json.debug-mode`)" section |
| `src/commands/json.debug.json` | Updated summary |

## Migration notes

- **No breaking change** for default deployments — these commands were not safe to call and now cleanly error out
- Developers using `KEYTABLE-CORRUPT` / `KEYTABLE-DISTRIBUTION` must now add `debug-mode yes` to the module load line
- New `KEYTABLE-CLEAR` command gives a recovery path for tests that intentionally inject handles
